### PR TITLE
whitespace changes in SPE3CASE1.DATA

### DIFF
--- a/tests/spe3/SPE3CASE1.DATA
+++ b/tests/spe3/SPE3CASE1.DATA
@@ -5,10 +5,10 @@
 
 -- Copyright (C) 2015 Statoil
 
--- This simulation is based on the data given in 
+-- This simulation is based on the data given in
 -- 'Third SPE Comparative Solution Project: Gas
 -- Cycling of Retrograde Condensate Reservoirs'
--- by D.E. Kenyon and G.A. Behie, 
+-- by D.E. Kenyon and G.A. Behie,
 -- Journal of Petroleum Technology, August 1987
 
 ----------------------------------------------------------------
@@ -19,9 +19,9 @@ RUNSPEC
 -- -------------------------------------------------------------
 
 TITLE
-	SPE 3 - CASE 1
+   SPE 3 - CASE 1
 DIMENS
-	9 9 4 /
+   9 9 4 /
 OIL
 GAS
 WATER
@@ -31,23 +31,23 @@ DISGAS
 FIELD
 
 START
-   1 'JAN' 2015 /
+    1 'JAN' 2015 /
 
 WELLDIMS
 -- Item 1: maximum number of wells in the model
--- 	   - there are two wells in the problem; injector and producer
+--      - there are two wells in the problem; injector and producer
 -- Item 2: maximum number of grid blocks connected to any one well
--- 	   - must be two as both wells are located at two grid blocks
+--      - must be two as both wells are located at two grid blocks
 -- Item 3: maximum number of groups in the model
--- 	   - we are dealing with only one 'group'
+--      - we are dealing with only one 'group'
 -- Item 4: maximum number of wells in any one group
--- 	   - there must be two wells in a group as there are two wells in total
-   2 2 1 2 /
+--      - there must be two wells in a group as there are two wells in total
+    2 2 1 2 /
 
 TABDIMS
 -- The max number of saturation and pressure nodes in the PROPS-tables
 -- exceeds the default -> item 3 and 4 in TABDIMS must be changed
-   1* 1* 30 30 /
+    1* 1* 30 30 /
 
 EQLDIMS
 /
@@ -65,41 +65,41 @@ GRID
 INIT
 
 -- ---------------------------------------------------------------
--- The values in this section are retrieved from table 2 
+-- The values in this section are retrieved from table 2
 -- and figure 1 in Kenyon & Behie
 NOECHO
-DX 
--- There are in total 324 cells with length 293.3ft in x-direction	
-   	324*293.3 /
+DX
+-- There are in total 324 cells with length 293.3ft in x-direction
+    324*293.3 /
 DY
 -- There are in total 324 cells with length 293.3ft in y-direction
-	324*293.3 /
+    324*293.3 /
 DZ
--- The layers are 30, 30, 50 and 50 ft thick 
+-- The layers are 30, 30, 50 and 50 ft thick
 -- In each layer there are 81 cells
-	81*30 81*30 81*50 81*50 /
+    81*30 81*30 81*50 81*50 /
 
 TOPS
 -- The depth of the top of each grid block
---	81*7315 81*7345 81*7375 81*7425 /
-	81*7315 /	
+--  81*7315 81*7345 81*7375 81*7425 /
+    81*7315 /
 
 PORO
 -- Constant porosity of 0.3 throughout all 324 grid cells
-   	324*0.13 /
+    324*0.13 /
 
 PERMX
--- The layers have horizontal (meaning x- and y-direction) permeability 
+-- The layers have horizontal (meaning x- and y-direction) permeability
 -- of 130mD, 40mD, 20mD and 150, respectively, from top to bottom layer.
-	81*130 81*40 81*20 81*150 /
+    81*130 81*40 81*20 81*150 /
 
 PERMY
-	81*130 81*40 81*20 81*150 /
+    81*130 81*40 81*20 81*150 /
 
 PERMZ
 -- z-direction permeability is 13mD, 4mD, 2mD and 15mD,respectively, from top
 -- to bottom layer
-	81*13 81*4 81*2 81*15 /
+    81*13 81*4 81*2 81*15 /
 ECHO
 
 PROPS
@@ -110,67 +110,69 @@ ROCK
 -- Item 2: rock compressibility (psi^{-1})
 
 -- Using values from table 2 in Kenyon & Behie:
-   	3550 4e-6 /
+    3550 4e-6 /
 
 
 SGOF
 -- Values taken from Kenyon & Behie's table 2
---	Sg	        Krg			 Kro(g)			Pc
+--  Sg          Krg       Kro(g)      Pc
 -- (first val 0)   (first val 0)    (only oil, gas & con. water)   (for oil-gas)
-	0.00		0.00			0.800 		0
-	0.04	  	0.005			0.650 		0
-	0.08	  	0.013			0.513 		0
-	0.12	  	0.026			0.400 		0
-	0.16	  	0.040			0.315      	0
-	0.20	  	0.058			0.250      	0
-	0.24	  	0.078			0.196      	0
-	0.28	  	0.100			0.150      	0
-	0.32	  	0.126			0.112      	0
-	0.36	  	0.156			0.082      	0
-	0.40	  	0.187			0.060      	0
-	0.44	  	0.222			0.040      	0
-	0.48	  	0.260			0.024      	0
-	0.52	  	0.300			0.012      	0
-	0.56	  	0.348			0.005      	0
-	0.60	  	0.400			0          	0
-	0.64	  	0.450			0          	0
-	0.68	  	0.505			0          	0
-	0.72	  	0.562			0     		0
-	0.76	  	0.620			0		0
-	0.80	  	0.680			0    		0
-	0.84	  	0.740			0     		0 /
--- Since Kenyon & Behie say that 'Relative permeability data were 
--- based on the simplistic assumption that the rel. perm. of 
--- any phase depends only on its saturation', the Kro values 
+    0.00    0.00     0.800    0
+    0.04    0.005    0.650    0
+    0.08    0.013    0.513    0
+    0.12    0.026    0.400    0
+    0.16    0.040    0.315    0
+    0.20    0.058    0.250    0
+    0.24    0.078    0.196    0
+    0.28    0.100    0.150    0
+    0.32    0.126    0.112    0
+    0.36    0.156    0.082    0
+    0.40    0.187    0.060    0
+    0.44    0.222    0.040    0
+    0.48    0.260    0.024    0
+    0.52    0.300    0.012    0
+    0.56    0.348    0.005    0
+    0.60    0.400    0        0
+    0.64    0.450    0        0
+    0.68    0.505    0        0
+    0.72    0.562    0        0
+    0.76    0.620    0        0
+    0.80    0.680    0        0
+    0.84    0.740    0        0
+    /
+-- Since Kenyon & Behie say that 'Relative permeability data were
+-- based on the simplistic assumption that the rel. perm. of
+-- any phase depends only on its saturation', the Kro values
 -- depend only on So, which is 1-Sg-Swc when only
 -- oil, gas and connate water are present. Swc=0.16 (= Swi here)
 SWOF
 -- Values taken from Kenyon & Behie's table 2
---	Sw		    Krw	0     		 Kro(w)			    Pc
+--  Sw        Krw  0          Kro(w)          Pc
 -- (first val is        (first val 0)         (only oil & water)       (for water-oil)
---  connate water sat) 		      (first val must be Krog at Sg=0)  
-    0.16	            0.00       	     0.800			   50
-    0.20		    0.002      	     0.650		     	   32
-    0.24		    0.010      	     0.513		     	   21
-    0.28		    0.020      	     0.400		           15.5
-    0.32		    0.033      	     0.315		     	   12.0
-    0.36		    0.049      	     0.250		     	   9.2
-    0.40		    0.066      	     0.196		     	   7.0
-    0.44		    0.090      	     0.150		     	   5.3
-    0.48		    0.119      	     0.112		     	   4.2
-    0.52		    0.150      	     0.082		     	   3.4
-    0.56		    0.186      	     0.060		           2.7
-    0.60		    0.227      	     0.040		           2.1
-    0.64		    0.277      	     0.024		     	   1.7
-    0.68		    0.330      	     0.012		     	   1.3
-    0.72		    0.390      	     0.005		     	   1.0
-    0.76		    0.462      	     0	     		   	   0.7
-    0.80		    0.540      	     0		     		   0.5
-    0.84		    0.620      	     0				   0.4
-    0.88		    0.710            0	     	     		   0.3
-    0.92		    0.800	     0	     	     		   0.2
-    0.96		    0.900	     0	     	     		   0.1
-    1.00		    1.000	     0	     	     		   0.0 /
+--  connate water sat)           (first val must be Krog at Sg=0)
+    0.16    0.00     0.800    50
+    0.20    0.002    0.650    32
+    0.24    0.010    0.513    21
+    0.28    0.020    0.400    15.5
+    0.32    0.033    0.315    12.0
+    0.36    0.049    0.250    9.2
+    0.40    0.066    0.196    7.0
+    0.44    0.090    0.150    5.3
+    0.48    0.119    0.112    4.2
+    0.52    0.150    0.082    3.4
+    0.56    0.186    0.060    2.7
+    0.60    0.227    0.040    2.1
+    0.64    0.277    0.024    1.7
+    0.68    0.330    0.012    1.3
+    0.72    0.390    0.005    1.0
+    0.76    0.462    0        0.7
+    0.80    0.540    0        0.5
+    0.84    0.620    0        0.4
+    0.88    0.710    0        0.3
+    0.92    0.800    0        0.2
+    0.96    0.900    0        0.1
+    1.00    1.000    0        0.0
+    /
 -- The Kro values depend only on So, which is 1-Sw when
 -- only oil and water are present
 -- Since we know Pcgw and since Pcog=0, we can conclude that Pcwo
@@ -185,12 +187,12 @@ SWOF
 DENSITY
 -- OilDens   WaterDens    GasDens
 -- lb/ft3     lb/ft3      lb/ft3
-   43.33       62.37      0.05850 /
+    43.33       62.37      0.05850 /
 --
 PVTW
---     RefPres        Bw          Cw           Vw         dVw
---       psia       rb/stb       1/psia        cP        1/psia
-       3427.6      1.02629    0.30698E-05   0.31107    0.59410E-05 /
+--  RefPres     Bw         Cw            Vw        dVw
+--  psia        rb/stb     1/psia        cP        1/psia
+    3427.6      1.02629    0.30698E-05   0.31107   0.59410E-05 /
 --
 -- Separator Conditions (from table 3 in Kenyon & Behie's paper)
 --  Tsep(F)    Psep(psia)
@@ -211,7 +213,7 @@ PVTW
 --MSCF/STB    psia     RB/STB          cP
 ------------------------------------------------------------
 PVTO
-  0.189473    500.0    1.20936          0.219 
+  0.189473    500.0    1.20936          0.219
              1000.0    1.19352          0.240
              1500.0    1.17997          0.260
              2000.0    1.16819          0.279
@@ -222,7 +224,7 @@ PVTO
              4000.0    1.13263          0.356
              4500.0    1.12574          0.374
              5000.0    1.11941          0.393  /
-  0.479365   1000.0    1.40215          0.149 
+  0.479365   1000.0    1.40215          0.149
              1500.0    1.37754          0.164
              2000.0    1.35701          0.179
              2500.0    1.33949          0.194
@@ -232,7 +234,7 @@ PVTO
              4000.0    1.29891          0.237
              4500.0    1.28817          0.251
              5000.0    1.27845          0.265  /
-  0.826985   1500.0    1.62448          0.113 
+  0.826985   1500.0    1.62448          0.113
              2000.0    1.58913          0.124
              2500.0    1.56020          0.135
              3000.0    1.53584          0.146
@@ -241,7 +243,7 @@ PVTO
              4000.0    1.49666          0.168
              4500.0    1.48052          0.179
              5000.0    1.46610          0.190  /
-  1.250165   2000.0    1.89110          0.089 
+  1.250165   2000.0    1.89110          0.089
              2500.0    1.84197          0.098
              3000.0    1.80234          0.107
              3427.6    1.77380          0.114
@@ -249,25 +251,25 @@ PVTO
              4000.0    1.74128          0.124
              4500.0    1.71695          0.132
              5000.0    1.69557          0.141  /
-  1.794854   2500.0    2.23421          0.073 
+  1.794854   2500.0    2.23421          0.073
              3000.0    2.16656          0.080
              3427.6    2.11974          0.086
              3500.0    2.11259          0.087
              4000.0    2.06805          0.093
              4500.0    2.03039          0.100
              5000.0    1.99794          0.106  /
-  2.549781   3000.0    2.71411          0.071 
+  2.549781   3000.0    2.71411          0.071
              3427.6    2.63221          0.076
              3500.0    2.61998          0.077
              4000.0    2.54537          0.083
              4500.0    2.48418          0.089
              5000.0    2.43271          0.094  /
-  2.951016   3427.6    2.96669          0.068 
+  2.951016   3427.6    2.96669          0.068
              3500.0    2.94777          0.069
              4000.0    2.83495          0.075
              4500.0    2.74550          0.080
              5000.0    2.67220          0.085  /
-  3.033715   3500.0    3.01897          0.068 
+  3.033715   3500.0    3.01897          0.068
              4000.0    2.90343          0.073
              4500.0    2.81181          0.079
              5000.0    2.73675          0.084 /
@@ -308,29 +310,29 @@ SOLUTION
 
 EQUIL
 -- Item 1: datum depth (ft)
--- 	   - Datum depth is at 7500ft (table 2, Kenyon & Behie)
+--      - Datum depth is at 7500ft (table 2, Kenyon & Behie)
 -- Item 2: pressure at datum depth (psia)
--- 	   - This is 3550psia (table 2, Kenyon & Behie)
+--      - This is 3550psia (table 2, Kenyon & Behie)
 -- Item 3: depth of water-oil contact
--- 	   - See comment under item 5
--- Item 4: oil-water capillary pressure at the water-oil contact 
---	   - Cap. pres. at gas-water contact is 0 (table 2, Kenyon & Behie)
---	   - Cap. pres. for gas-oil is assumed 0 (table 2, Kenyon & Behie)
---	   - This means oil-water cap. pres. is 0 at contact
+--      - See comment under item 5
+-- Item 4: oil-water capillary pressure at the water-oil contact
+--     - Cap. pres. at gas-water contact is 0 (table 2, Kenyon & Behie)
+--     - Cap. pres. for gas-oil is assumed 0 (table 2, Kenyon & Behie)
+--     - This means oil-water cap. pres. is 0 at contact
 -- Item 5: depth of gas-oil contact (ft)
---	   - Since all oil is initially contained in the gas phase,
---	     we can set item 5 equal to item 3, which must be
---	     set to the gas-water contact (since we have assumed no oil)
---	     The gas-water contact is at 7500ft (table 2, Kenyon & Behie)
+--     - Since all oil is initially contained in the gas phase,
+--       we can set item 5 equal to item 3, which must be
+--       set to the gas-water contact (since we have assumed no oil)
+--       The gas-water contact is at 7500ft (table 2, Kenyon & Behie)
 -- Item 6: gas-oil capillary pressure at gas-oil contact (psi)
---	   - Kenyon & Behie say this is assumed to be zero
+--     - Kenyon & Behie say this is assumed to be zero
 -- Item 7: RSVD-table
 -- Item 8: RVVD-table
 -- Item 9: must set to 0 as only this is supported in OPM
 
--- Item #: 1 	2    3    4 5    6 7 8 9
-   	   7500 3550 7500 0 7500 0 0 0 0 /
---	   	     	    	 
+-- Item #: 1   2    3    4 5    6 7 8 9
+    7500 3550 7500 0 7500 0 0 0 0 /
+--
 SUMMARY
 
 WOPR
@@ -347,42 +349,42 @@ FOPT
 
 BOSAT
 -- Oil Saturation in lower cell block of production well
-  7 7 4 /
+    7 7 4 /
 /
 
 BRS
-  7 7 4 /
-  1 1 1 /
-  9 9 1 /
-  9 1 4 /
-  1 9 1 /
-  4 4 4 /
+    7 7 4 /
+    1 1 1 /
+    9 9 1 /
+    9 1 4 /
+    1 9 1 /
+    4 4 4 /
 /
 
 -- In order to compare Eclipse with Flow:
 WBHP
-  'INJ'
-  'PROD'
+    'INJ'
+    'PROD'
 /
 WGIR
-  'INJ'
-  'PROD'
+    'INJ'
+    'PROD'
 /
 -- $$$ WGIT
 -- $$$   'INJ'
 -- $$$   'PROD'
 -- $$$ /
 WGPR
-  'INJ'
-  'PROD'
+    'INJ'
+    'PROD'
 /
 -- $$$ WGPT
 -- $$$   'INJ'
 -- $$$   'PROD'
 -- $$$ /
 WOIR
-  'INJ'
-  'PROD'
+    'INJ'
+    'PROD'
 /
 -- $$$ WOIT
 -- $$$   'INJ'
@@ -397,16 +399,16 @@ WOIR
 -- $$$   'PROD'
 -- $$$ /
 WWIR
-  'INJ'
-  'PROD'
+    'INJ'
+    'PROD'
 /
 -- $$$ WWIT
 -- $$$   'INJ'
 -- $$$   'PROD'
 -- $$$ /
 WWPR
-  'INJ'
-  'PROD'
+    'INJ'
+    'PROD'
 /
 -- $$$ WWPT
 -- $$$   'INJ'
@@ -416,51 +418,51 @@ WWPR
 SCHEDULE
 
 RPTRST
-	'BASIC=4' /
+    'BASIC=4' /
 
 --DRSDT
 -- 0 /
--- GOR cannot rise and free gas does not dissolve in undersaturated 
--- oil when setting DRSDT to 0, 
+-- GOR cannot rise and free gas does not dissolve in undersaturated
+-- oil when setting DRSDT to 0,
 -- Notice that all GOR curves are decreasing
 -- -> adding DRSDT=0 should not make difference
 -- No difference in BOSAT, FOPR and FOPT graphs when including DRSDT=0
 
 WELSPECS
--- Item #: 1	  2	3 4 5	  6
-   	 'PROD'  'G1'	7 7 7375 'GAS' /
-	 'INJ'   'G1'	1 1 7315 'GAS' /
+-- Item #: 1    2  3 4 5    6
+    'PROD'  'G1'  7 7 7375 'GAS' /
+    'INJ'   'G1'  1 1 7315 'GAS' /
 /
 -- The coordinates in item 3-4 are retrieved from figure 1 in Kenyon & Behie
 -- Ref. manual says the top-most perforation of the well is the
--- recommended value for datum depth for BHP (item 5), which are the values 
+-- recommended value for datum depth for BHP (item 5), which are the values
 -- that are entered above
 -- Both oil and gas are produced, and 'GAS' has been chosen as preferred
 -- phase (item 6) for PROD. All graphs will be identical if choosing OIL
 
 COMPDAT
--- Item #: 1	2 3 4 5	 6	7  8	9
-   	 'PROD' 7 7 3 4	'OPEN'	1* 1*	2 /
-	 'INJ'	1 1 1 2	'OPEN'	1* 1*	2 /
+-- Item #: 1  2 3 4 5   6  7  8  9
+    'PROD' 7 7 3 4  'OPEN'  1* 1*  2 /
+    'INJ'  1 1 1 2  'OPEN'  1* 1*  2 /
 /
 -- The coordinates in item 2-5 are retrieved from figure 1 in Kenyon & Behie
--- Item 9 is the well bore internal diameter, 
+-- Item 9 is the well bore internal diameter,
 -- the radius is given to be 1ft in Kenyon & Behie's paper
 
 
 WCONPROD
--- Item #: 1	  2	 3	  6       9
-   	  'PROD' 'OPEN' 'GRAT' 2* 6200 2* 500 /
+-- Item #: 1    2   3    6       9
+    'PROD' 'OPEN' 'GRAT' 2* 6200 2* 500 /
 /
--- It is stated in Kenyon & Behie's table 3 that the production is 
+-- It is stated in Kenyon & Behie's table 3 that the production is
 -- controlled by a separator gas rate of 6200Mscf per day (item 6)
 -- Kenyon & Behie also say that min BHP is 500psi (item 9)
 
 WCONINJE
--- Item #: 1	  2	 3	 4      5     6   7 
-   	  'INJ'	 'GAS'  'OPEN'  'RATE'  4700  1*  4000 /
+-- Item #: 1    2   3   4      5     6   7
+    'INJ'   'GAS'  'OPEN'  'RATE'  4700  1*  4000 /
 /
--- In Case 1, Kenyon & Behie require a constant recycle-gas rate of 
+-- In Case 1, Kenyon & Behie require a constant recycle-gas rate of
 -- 4700Mscf per day (item 5) for ten years
 -- Kenyon & Behie say max BHP is 4000psi (item 7)
 
@@ -468,31 +470,31 @@ TSTEP
 -- first year:
 7*52.14285714
 -- next nine years:
-31 28 31 30 31 30 31 31 30 31 30 31 
-31 28 31 30 31 30 31 31 30 31 30 31 
-31 28 31 30 31 30 31 31 30 31 30 31 
 31 28 31 30 31 30 31 31 30 31 30 31
-31 28 31 30 31 30 31 31 30 31 30 31 
-31 28 31 30 31 30 31 31 30 31 30 31 
-31 28 31 30 31 30 31 31 30 31 30 31 
-31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
+31 28 31 30 31 30 31 31 30 31 30 31
 31 28 31 30 31 30 31 31 30 31 30 31 /
 
--- The cycling period ends after ten years, 
+-- The cycling period ends after ten years,
 -- so we need to set item 5 in WCONINJE to 0:
 WCONINJE
--- Item #: 1	  2	 3	 4      5  6   7 
-   	  'INJ'	 'GAS'  'OPEN'  'RATE'  0  1*  4000 /
+-- Item #: 1    2   3   4      5  6   7
+    'INJ'   'GAS'  'OPEN'  'RATE'  0  1*  4000 /
 /
 
 TSTEP
 -- Advance the simulator once a month for next 5 years
 -- because Kenyon & Behie say models are to run for a total of 15 years
-31 28 31 30 31 30 31 31 30 31 30 31 
-31 28 31 30 31 30 31 31 30 31 30 31 
-31 28 31 30 31 30 31 31 30 31 30 31 
-31 28 31 30 31 30 31 31 30 31 30 31 
-31 28 31 30 31 30 31 31 30 31 30 31 /
-
+    31 28 31 30 31 30 31 31 30 31 30 31
+    31 28 31 30 31 30 31 31 30 31 30 31
+    31 28 31 30 31 30 31 31 30 31 30 31
+    31 28 31 30 31 30 31 31 30 31 30 31
+    31 28 31 30 31 30 31 31 30 31 30 31
+/
 
 END


### PR DESCRIPTION
This is a trivial change, and indeed if one runs `diff -w` to disable whitespace changes there are no changes.

Ran `M-x whitespace-cleanup` and a couple of occurrences of `C-u M-x align`.

No semantic difference.