### PR TITLE
Adapt to change in schedule.getTimeMap in opm-parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - "2.7"
@@ -19,40 +20,26 @@ addons:
       - libeigen3-dev
 before_script:
   - export CXX="g++-4.8" CC="gcc-4.8" FC="gfortran-4.8"
-  - SUNBEAM_ROOT=(`pwd`)
-  - echo $SUNBEAM_ROOT
-  - cd ..
-  - SUN_ROOT=(`pwd`)
-  - echo $SUN_ROOT
-  - git clone https://github.com/Ensembles/ert.git
-  - git clone https://github.com/OPM/opm-common.git
+  - pushd ..
+  - INSTALL_ROOT=$PWD/install
+  - git clone https://github.com/Statoil/libecl.git
   - git clone https://github.com/OPM/opm-parser.git
-  - cd ert
-  - ERT_ROOT=(`pwd`)
-  - echo $ERT_ROOT
-  - mkdir build
-  - cd build
-  - cmake -DBUILD_PYTHON=OFF -DBUILD_TESTS=OFF ..
-  - make
-  - cd $SUN_ROOT/opm-common
-  - OPM_COMMON_ROOT=(`pwd`)
-  - echo $OPM_COMMON_ROOT
-  - mkdir build
-  - cd build
-  - cmake ..
-  - make
-  - cd $SUN_ROOT/opm-parser
-  - OPM_PARSER_ROOT=(`pwd`)
-  - echo $OPM_PARSER_ROOT
-  - mkdir build
-  - cd build
-  - cmake -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON ..
-  - make
-  - cd $SUNBEAM_ROOT
+  - mkdir libecl/build
+  - pushd libecl/build
+  - cmake -DBUILD_PYTHON=OFF -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT ..
+  - make install
+  - popd
+  - mkdir opm-parser/build
+  - pushd opm-parser/build
+  - cmake -DCMAKE_MODULE_PATH=$INSTALL_ROOT/share/cmake/Modules -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON ..
+  - make install
+  - popd
+  - popd
   - mkdir build
   - cd build
 
 script:
-  - cmake -DCMAKE_MODULE_PATH=$OPM_COMMON_ROOT/cmake/Modules ..
+  - cmake -DCMAKE_MODULE_PATH=$INSTALL_ROOT/share/cmake/Modules -Dopm-parser_DIR=$INSTALL_ROOT/lib/cmake/opm-parser ..
   - make
+  - export PYTHONPATH=$PYTHONPATH:python
   - ctest --output-on-failure

--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
-# sunbeam ![build status](https://travis-ci.org/Statoil/sunbeam.svg?branch=master "TravisCI Build Status")
+# sunbeam [![Build Status](https://travis-ci.org/Statoil/sunbeam.svg?branch=master)](https://travis-ci.org/Statoil/sunbeam)
+
+
+# Prerequisites:
+
+Clone and build `ecl` from [Statoil/libecl](https://github.com/Statoil/libecl)
+and `opm-parser` from [OPM/opm-parser](https://github.com/OPM/opm-parser).
+
+```
+git clone https://github.com/Statoil/libecl
+git clone https://github.com/OPM/opm-parser
+mkdir libecl/build
+mkdir opm-parser/build
+pushd libecl/build
+cmake ..
+make install
+popd
+pushd opm-parser/build
+cmake ..
+make install
+```
 
 # Quick start (WIP)
 Assumes you have built (and maybe installed) opm-parser
 
 ```bash
-git clone --recursive https://github.com/statoil/sunbeam
-cd sunbeam
-mkdir build
-cd build
-cmake .. -DCMAKE_MODULE_PATH=$OPM_COMMON_ROOT/cmake/Modules
+git clone --recursive https://github.com/Statoil/sunbeam
+mkdir sunbeam/build
+pushd sunbeam/build
+cmake ..
 make
 ctest # for running unit tests
 ```

--- a/python/sunbeam/sunbeam.cpp
+++ b/python/sunbeam/sunbeam.cpp
@@ -217,11 +217,13 @@ boost::posix_time::ptime get_end_time( const Schedule& s ) {
 }
 
 py::list get_timesteps( const Schedule& s ) {
+    namespace time = boost::posix_time;
     const auto& tm = s.getTimeMap();
-    std::vector< boost::posix_time::ptime > v;
+    std::vector< time::ptime > v;
     v.reserve( tm.size() );
 
-    for( size_t i = 0; i < tm.size(); ++i ) v.push_back( tm[ i ] );
+    for( size_t i = 0; i < tm.size(); ++i )
+        v.push_back( time::from_time_t(tm[ i ]) );
 
     return iterable_to_pylist( v );
 }


### PR DESCRIPTION
The API of OPM/opm-parser changed, so we adapt to that.

Move to Statoil/libecl for the `ecl` library.