### PR TITLE
Optionally enable RPATH in top level cmake file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - libsuitesparse-dev
       - libeigen3-dev
 before_script:
+  - export PYTHON_VERSION="2.7"
   - export CXX="g++-4.8" CC="gcc-4.8" FC="gfortran-4.8"
   - pushd ..
   - export INSTALL_ROOT=$PWD/install
@@ -38,7 +39,8 @@ before_script:
   - mkdir build
   - cd build
 
+script:
   - cmake -DCMAKE_PREFIX_PATH=$INSTALL_ROOT -DUSE_RPATH=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT ..
   - make install
-  - export PYTHONPATH=$PYTHONPATH:install/lib/python${PYTHON_VERSION}/site-packages
+  - export PYTHONPATH=$PYTHONPATH:$INSTALL_ROOT/lib/python${PYTHON_VERSION}/site-packages
   - ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 before_script:
   - export CXX="g++-4.8" CC="gcc-4.8" FC="gfortran-4.8"
   - pushd ..
-  - INSTALL_ROOT=$PWD/install
+  - export INSTALL_ROOT=$PWD/install
   - git clone https://github.com/Statoil/libecl.git
   - git clone https://github.com/OPM/opm-parser.git
   - mkdir libecl/build
@@ -31,15 +31,14 @@ before_script:
   - popd
   - mkdir opm-parser/build
   - pushd opm-parser/build
-  - cmake -DCMAKE_MODULE_PATH=$INSTALL_ROOT/share/cmake/Modules -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON ..
+  - cmake -DCMAKE_PREFIX_PATH=$INSTALL_ROOT -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON ..
   - make install
   - popd
   - popd
   - mkdir build
   - cd build
 
-script:
-  - cmake -DCMAKE_MODULE_PATH=$INSTALL_ROOT/share/cmake/Modules -Dopm-parser_DIR=$INSTALL_ROOT/lib/cmake/opm-parser ..
-  - make
-  - export PYTHONPATH=$PYTHONPATH:python
+  - cmake -DCMAKE_PREFIX_PATH=$INSTALL_ROOT -DUSE_RPATH=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT ..
+  - make install
+  - export PYTHONPATH=$PYTHONPATH:install/lib/python${PYTHON_VERSION}/site-packages
   - ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,5 +19,11 @@ find_package( Boost COMPONENTS python REQUIRED )
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/pycmake/cmake/Modules)
 
+option( USE_RPATH "Embed RPATH in libraries and binaries" OFF)
+if (USE_RPATH)
+    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif ()
+
 add_subdirectory( python )
 add_subdirectory( tests )


### PR DESCRIPTION
If sunbeam is compled with `-DUSE_RPATH=ON` the libraries linked to by `sunbeam.so`will have their path embedded in the shared library.