### PR TITLE
Forward docstrings from C++

### DIFF
--- a/python/sunbeam/sunbeam.py
+++ b/python/sunbeam/sunbeam.py
@@ -28,6 +28,8 @@ def delegate(delegate_cls, to = '_sun'):
         setattr(cls, to, _property())
         for attr in attributes - set(cls.__dict__.keys() + ['__init__']):
             setattr(cls, attr, _delegate(to, attr))
+            src, dst = getattr(delegate_cls, attr), getattr(cls, attr)
+            setattr(dst, '__doc__', src.__doc__)
 
         def new__new__(_cls, this, *args, **kwargs):
             new = super(cls, _cls).__new__(_cls, *args, **kwargs)


### PR DESCRIPTION
Some of the user facing functions and methods in sunbeam have no
implementation in the python-defined classes, but are forwarded from
boost python. This forwarding is done by hijacking the method call at
runtime, which means that python help() cannot resolve the docstring.

Copy the docstring into the hijacking attribute so that the docstring is
available as if the method/function was implemented directly in python.

help(eclipse_state_object) will now correcly forward the docstrings from
the forwarded EclipseState class.