### PR TITLE
Class setup

### DIFF
--- a/tests/completions.py
+++ b/tests/completions.py
@@ -2,13 +2,12 @@ import unittest
 import sunbeam
 
 class TestWells(unittest.TestCase):
-    spe3 = None
 
-    def setUp(self):
-        if self.spe3 is None:
-            self.spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
-        self.timesteps = self.spe3.schedule.timesteps
-        self.wells = self.spe3.schedule.wells
+    @classmethod
+    def setUpClass(cls):
+        cls.spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
+        cls.timesteps = cls.spe3.schedule.timesteps
+        cls.wells = cls.spe3.schedule.wells
 
     def test_completion_pos(self):
         p00 = self.wells[0].completions(0)[0].pos

--- a/tests/props.py
+++ b/tests/props.py
@@ -2,7 +2,6 @@ import unittest
 import sunbeam
 
 class TestProps(unittest.TestCase):
-    spe3 = None
 
     def assertClose(self, expected, observed, epsilon=1e-08):
         diff = abs(expected - observed)
@@ -10,8 +9,7 @@ class TestProps(unittest.TestCase):
         self.assertTrue(diff <= epsilon, msg=err_msg)
 
     def setUp(self):
-        if self.spe3 is None:
-            self.spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
+        self.spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
         self.props = self.spe3.props()
 
     def test_repr(self):

--- a/tests/schedule.py
+++ b/tests/schedule.py
@@ -5,12 +5,11 @@ import sunbeam
 spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
 
 class TestSchedule(unittest.TestCase):
-    spe3 = None
 
-    def setUp(self):
-        if self.spe3 is None:
-            self.spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
-        self.sch = spe3.schedule
+    @classmethod
+    def setUpClass(cls):
+        cls.spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
+        cls.sch = cls.spe3.schedule
 
     def testWells(self):
         self.assertEqual(2, len(self.sch.wells))

--- a/tests/state.py
+++ b/tests/state.py
@@ -2,8 +2,6 @@ import unittest
 import sunbeam
 
 class TestState(unittest.TestCase):
-
-    spe3 = None
     FAULTS_DECK = """
 RUNSPEC
 
@@ -49,12 +47,12 @@ SATNUM
 \
 """
 
-    def setUp(self):
-        if self.spe3 is None:
-            self.spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
-            self.cpa = sunbeam.parse('data/CORNERPOINT_ACTNUM.DATA')
-        self.state = self.spe3
-        self.cp_state = self.cpa
+    @classmethod
+    def setUpClass(cls):
+        cls.spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
+        cls.cpa = sunbeam.parse('data/CORNERPOINT_ACTNUM.DATA')
+        cls.state = cls.spe3
+        cls.cp_state = cls.cpa
 
     def test_repr_title(self):
         self.assertTrue('EclipseState' in repr(self.state))

--- a/tests/wells.py
+++ b/tests/wells.py
@@ -2,13 +2,12 @@ import unittest
 import sunbeam
 
 class TestWells(unittest.TestCase):
-    spe3 = None
 
-    def setUp(self):
-        if self.spe3 is None:
-            self.spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
-        self.timesteps = self.spe3.schedule.timesteps
-        self.wells = self.spe3.schedule.wells
+    @classmethod
+    def setUpClass(cls):
+        cls.spe3 = sunbeam.parse('spe3/SPE3CASE1.DATA')
+        cls.timesteps = cls.spe3.schedule.timesteps
+        cls.wells = cls.spe3.schedule.wells
 
     def inje(self):
         return next(iter(filter(sunbeam.Well.injector(0), self.wells)))


### PR DESCRIPTION
I have started the work of updating sunbeam to work with opm-parser/master. In that process I encountered unrelated test errors[1] which I concluded were related to this initialization pattern:

```
class TestCase(unittest.TestCase):
      class_member = None

      def setUp(self):
            if self.class_member is None:
                    self.class_member = create_new_member( )
```
I have not looked in detail on how the tests in a testclass are executed, but I am quite certain that each test method is run with it's own self instance, and the point is that the `self.class_member = create_new_member()` assignment does not assign to the class member used in the next instantiation.

This PR does not change anything with respect to the opm-parser branch, but the tests are initialized using the classmethod `setUpClass(cls)` instead. 

[1]: I can not reproduce the errors on current sunbeam/master, but the errors are semi-reproducible (consistent with some GC/memory variation) on my feature branch, and these fixes fix the problems on that branch.


  