### PR TITLE
WIP: Add VFP Table to Group

### DIFF
--- a/python/sunbeam/schedule.py
+++ b/python/sunbeam/schedule.py
@@ -124,6 +124,11 @@ class Group(object):
         return [w for w in self._schedule.wells if w.name in names]
 
     @property
+    def vfp_table(self):
+        vfp_table = self._vfp_table(self.timestep)
+        return vfp_table
+
+    @property
     def parent(self):
         par = self._schedule._group_tree(self.timestep)._parent(self.name)
         if self.name == 'FIELD':

--- a/sunbeam/group.cpp
+++ b/sunbeam/group.cpp
@@ -8,12 +8,17 @@ namespace {
     py::list wellnames( const Group& g, size_t timestep ) {
         return iterable_to_pylist( g.getWells( timestep )  );
     }
+
+     int get_vfp_table( const Group& g, size_t timestep ) {
+        return g.getGroupNetVFPTable(timestep);
+    }
 }
 
 void sunbeam::export_Group() {
 
     py::class_< Group >( "Group", py::no_init )
         .add_property( "name", mkcopy( &Group::name ) )
+        .def( "_vfp_table", &get_vfp_table )
         .def( "_wellnames", &wellnames )
         ;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ configure_file(data/CORNERPOINT_ACTNUM.DATA data/CORNERPOINT_ACTNUM.DATA COPYONL
 configure_file(data/JFUNC.DATA data/JFUNC.DATA COPYONLY)
 
 
-foreach(prog completions deck group_tree parse_deck parse state props schedule wells)
+foreach(prog completions deck group_tree grupnet parse_deck parse state props schedule wells)
+
     add_python_test(${prog} ${prog}.py)
 endforeach()

--- a/tests/grupnet.py
+++ b/tests/grupnet.py
@@ -1,0 +1,20 @@
+import unittest
+import sunbeam
+
+
+class TestGrupnet(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        norne = '../../examples/data/norne/NORNE_ATW2013.DATA'
+        cls.es = sunbeam.parse(norne, ('PARSE_RANDOM_SLASH', sunbeam.action.ignore))
+
+    def test_vfp_table(self):
+        self.assertEqual(0, self.es.schedule.group(timestep=0)['PROD'].vfp_table)
+        self.assertEqual(9, self.es.schedule.group(timestep=0)['MANI-E2'].vfp_table)
+        self.assertEqual(9, self.es.schedule.group(timestep=247)['MANI-E2'].vfp_table)
+        self.assertEqual(9999, self.es.schedule.group(timestep=0)['MANI-K1'].vfp_table)
+        self.assertEqual(0, self.es.schedule.group(timestep=0)['INJE'].vfp_table)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
VFP table is added from GRUPNET for further use related to GroupTree in Webportalen. This PR is dependent on merging of https://github.com/OPM/opm-parser/pull/1169 in OPM-parser, and Sunbeam working with master of OPM-parser

After sketching a way to solve this task with Deck in Sunbeam, we figured out that retrieving the data from EclipseState in OPM-parser would be much easier and generate a better solution